### PR TITLE
chore: added issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: hwakabh
+
+---
+
+## Bug Description
+Brief descriptions of bugs:
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+Clear and concise description of what you expected to happen
+
+## Environment
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+ - Device: [e.g. iPhone6]
+
+## (Optional)Additional context
+Add any other context about the problem here.
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/generic-template.md
+++ b/.github/ISSUE_TEMPLATE/generic-template.md
@@ -1,0 +1,14 @@
+---
+name: Generic Template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: hwakabh
+
+---
+
+## AsIs
+
+## ToDo
+
+## (Optional) Acceptance Criteria

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,7 @@
+# Issue link
+Closes: #
+Relates: #
+
+# Changes in this PR
+
+# Changes not included in this PR


### PR DESCRIPTION
## Issue Link
Closes: #9

## Changes in this PR
- Added issue templates, via GitHub UI
- Pushed PR templates in `.github/` directory

## Changes not included in this PR
e2e testing of raise issue/PR