### PR TITLE
build: applied custom domain with ingress-nginx

### DIFF
--- a/manifests/fastapi.yaml
+++ b/manifests/fastapi.yaml
@@ -49,4 +49,4 @@ spec:
     targetPort: 8080
   selector:
     app: random-travelers
-  type: LoadBalancer
+  type: ClusterIP

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app
+  namespace: random-travelers
+  annotations:
+    cert-manager.io/issuer: "letsencrypt"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - random-travelers.com
+      # cert-manager automatically generate secret
+      secretName: tls-cert
+  rules:
+    - host: random-travelers.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fastapi
+                port:
+                  number: 80

--- a/manifests/issuer.yaml
+++ b/manifests/issuer.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt
+  namespace: random-travelers
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: 'hrykwkbys1024@gmail.com'
+    # cert-manager automatically generate secret
+    privateKeySecretRef:
+      name: ca-letsencrypt
+    solvers:
+      - http01:
+          ingress:
+            class: nginx


### PR DESCRIPTION
# Issue link
Relates: #94

# Changes in this PR
- added manifests for setting up TLS certifications of custom domain with `cert-manager`
- added ingress manifests for enabling custom domain on GKE namespace

# Changes not included in this PR
cert-manager have been already installed onto GKE cluster, so we need not to include its manifests in this PR.