### PR TITLE
refactor: replace builds with Nixpacks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,12 +7,6 @@ on:
       - '!main'
   workflow_dispatch:
 
-env:
-  MYSQL_HOST: 127.0.0.1
-  MYSQL_USER: root
-  MYSQL_PASSWORD: root
-  MYSQL_DATABASE: rt
-
 jobs:
   build:
     name: Build image
@@ -43,14 +37,24 @@ jobs:
           trivy-config: .github/configs/trivy.yaml
           # https://github.com/aquasecurity/trivy-action
 
-      - name: Install nixpacks CLI and build image
-        run: |
-          curl -sSL https://nixpacks.com/install.sh | bash
-          nixpacks build . --name random-travelers:local \
-            --env MYSQL_HOST=${{ env.MYSQL_HOST }} \
-            --env MYSQL_USER=${{ env.MYSQL_USER }} \
-            --env MYSQL_PASSWORD=${{ env.MYSQL_PASSWORD }} \
-            --env MYSQL_DATABASE=${{ env.MYSQL_DATABASE }}
+      # - name: Install nixpacks CLI and build image
+      #   run: |
+      #     curl -sSL https://nixpacks.com/install.sh | bash
+      #     nixpacks build . --name random-travelers:local
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        # https://github.com/docker/login-action#github-container-registry
+
+      - name: Build and push Docker images
+        uses: iloveitaly/github-action-nixpacks@main
+        with:
+          push: false
+          tags: random-travelers:local
 
       # - name: Sanity Check with /healthz
       #   env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,12 @@ on:
       - '!main'
   workflow_dispatch:
 
+env:
+  MYSQL_HOST: 127.0.0.1
+  MYSQL_USER: root
+  MYSQL_PASSWORD: root
+  MYSQL_DATABASE: rt
+
 jobs:
   build:
     name: Build image
@@ -37,16 +43,14 @@ jobs:
           trivy-config: .github/configs/trivy.yaml
           # https://github.com/aquasecurity/trivy-action
 
-      - name: Install pack
-        uses: buildpacks/github-actions/setup-pack@v5.8.3
-        # https://github.com/buildpacks/github-actions#setup-pack-cli-action
-
-      - name: Build image locally
+      - name: Install nixpacks CLI and build image
         run: |
-          pack build ghcr.io/hwakabh/random-travelers:latest \
-            --builder gcr.io/buildpacks/builder:latest \
-            --path . \
-            --env "$(cat .python-version)" \
+          curl -sSL https://nixpacks.com/install.sh | bash
+          nixpacks build . --name random-travelers:local \
+            --env MYSQL_HOST=${{ env.MYSQL_HOST }} \
+            --env MYSQL_USER=${{ env.MYSQL_USER }} \
+            --env MYSQL_PASSWORD=${{ env.MYSQL_PASSWORD }} \
+            --env MYSQL_DATABASE=${{ env.MYSQL_DATABASE }}
 
       # - name: Sanity Check with /healthz
       #   env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,19 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: '.python-version'
-
-      # Note that poerty command will be used only for exporting deps in this workflow
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-
-      - name: Generate requirements.txt for Google Cloud buildpacks
-        run: |
-          poetry export -o requirements.txt --without-hashes
-
       - name: Security Test of Trivy with filesystem-mode
         uses: aquasecurity/trivy-action@master
         with:
@@ -36,11 +23,6 @@ jobs:
           scan-ref: './'
           trivy-config: .github/configs/trivy.yaml
           # https://github.com/aquasecurity/trivy-action
-
-      # - name: Install nixpacks CLI and build image
-      #   run: |
-      #     curl -sSL https://nixpacks.com/install.sh | bash
-      #     nixpacks build . --name random-travelers:local
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
 jobs:
   build_and_ship:
     name: Build & Ship OCI image
@@ -22,21 +25,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         # https://github.com/docker/login-action#github-container-registry
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-
-      - name: Generate requirements.txt for Google Cloud buildpacks
-        run: |
-          poetry export -o requirements.txt --without-hashes
-
-      - name: Install pack
-        uses: buildpacks/github-actions/setup-pack@v5.8.3
-        # https://github.com/buildpacks/github-actions#setup-pack-cli-action
-
-      - name: Publish packages
-        run: |
-          pack build ghcr.io/hwakabh/random-travelers:latest \
-            --builder gcr.io/buildpacks/builder:latest \
-            --path . \
-            --env "$(cat .python-version)" \
-            --publish
+      - name: Build and push Docker images
+        uses: iloveitaly/github-action-nixpacks@main
+        with:
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := help
 
 MYSQL_CONTAINER_NAME := "rt-mysql"
-MYSQL_ROOT_PASSWORD := "rt"
-MYSQL_DATABASE := "root"
+MYSQL_ROOT_PASSWORD := "root"
+MYSQL_DATABASE := "rt"
 
 # all targets are phony
 .PHONY: $(shell egrep -o ^[a-zA-Z_-]+: $(MAKEFILE_LIST) | sed 's/://')

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := help
 
 MYSQL_CONTAINER_NAME := "rt-mysql"
+MYSQL_ROOT_PASSWORD := "rt"
+MYSQL_DATABASE := "root"
 
 # all targets are phony
 .PHONY: $(shell egrep -o ^[a-zA-Z_-]+: $(MAKEFILE_LIST) | sed 's/://')
@@ -26,8 +28,8 @@ db: --check-docker ## Starting MySQL container
 	@docker start ${MYSQL_CONTAINER_NAME} 2> /dev/null || docker run -d \
 		--name ${MYSQL_CONTAINER_NAME} \
 		-p 3306:3306 \
-		-e MYSQL_DATABASE='rt' \
-		-e MYSQL_ROOT_PASSWORD='root' \
+		-e MYSQL_DATABASE=${MYSQL_DATABASE} \
+		-e MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD} \
 		--health-cmd "mysqladmin ping --user=root --password=root" \
 		--health-interval 10s \
 		--health-retries 5 \

--- a/app/database.py
+++ b/app/database.py
@@ -8,29 +8,31 @@ from app.config import app_settings
 
 
 # dialect for using with mysql-connector-python
-SQLALCHEMY_DATABASE_URL = "mysql+mysqlconnector://{user}:{password}@{host}:{port}/{dbname}".format(
+ENGINE_URL = "mysql+mysqlconnector://{user}:{password}@{host}:{port}".format(
     user=app_settings.MYSQL_USER,
     password=app_settings.MYSQL_PASSWORD,
     host=app_settings.MYSQL_HOST,
     port=3306,
-    dbname=app_settings.MYSQL_DATABASE
 )
 
+# Create database for first migrations
+with create_engine(ENGINE_URL).connect() as conn:
+    conn.execute(text(f'CREATE DATABASE IF NOT EXISTS {app_settings.MYSQL_DATABASE}'))
 
 # Configurations for returing database instances
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL,
-    echo=False
+    ENGINE_URL + '/' + app_settings.MYSQL_DATABASE,
+    echo=False,
 )
 
-SessionLocal = sessionmaker(
-    autocommit=False,
-    autoflush=False,
-    bind=engine
-)
 
 def get_db():
-    db = SessionLocal()
+    db = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=engine
+    )
+
     try:
         yield db
     finally:

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,11 @@
+# https://nixpacks.com/docs/configuration/file
+
+providers = ["python"]
+buildImage = 'ghcr.io/railwayapp/nixpacks:latest'
+
+[phases.setup]
+nixPkgs = ["gcc", "python313"]
+
+[variables]
+NIXPACKS_NO_CACHE='true'
+NIXPACKS_POETRY_VERSION='1.8.5'

--- a/poetry.lock
+++ b/poetry.lock
@@ -728,5 +728,5 @@ standard = ["colorama (>=0.4)", "httptools (>=0.6.3)", "python-dotenv (>=0.13)",
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.13.1"
-content-hash = "50565a83a08ee111e475924dfeea3b0b3ef8ca1020a5d981680c5c9589eadcc0"
+python-versions = "~3.13"
+content-hash = "433afc1d66408c30543c9693dd45d650a58685d45540f31542774d813e7df46b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{include = "app"}]
 
 [tool.poetry.dependencies]
-python = "^3.13.1"
+python = "~3.13"
 numpy = "^2.2.1"
 mysql-connector-python = "^9.1.0"
 fastapi = "^0.115.6"


### PR DESCRIPTION
# Issue link
Relates: #114 

# Changes in this PR
- made `MYSQL_ROOT_PASSWORD` and `MYSQL_DATABASE` variables in Makefile
- added features to create database with SQLAlchemy if there is no database provided by `MYSQL_DATABASE`
- added [`github-action-nixpacks`](https://github.com/iloveitaly/github-action-nixpacks) for Build/Publish CI
- removed jobs related to pack-cli from Build/Publish CI
- added nixpacks.toml for declarative configurations of image builds by Nixpacks
- locked minimal Python version with `3.13.0` and updated lockfiles

# Changes not included in this PR
N/A