### PR TITLE
ci: explicitly provided ubuntu-24.04 as base images.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   clean-ghcr:
     name: Delete old unused container images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Delete old images
         uses: snok/container-retention-policy@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_and_ship:
     name: Build & Ship OCI image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-labeler.yaml
+++ b/.github/workflows/pull-request-labeler.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Issue link
N/A

# Changes in this PR
Explicitly providing `ubuntu-24.04` as base images for suppressing warnings:
```shell
ubuntu-latest pipelines will use ubuntu-24.04 soon.
For more details, see https://github.com/actions/runner-images/issues/10636
```

# Changes not included in this PR
N/A