### PR TITLE
feat(deploy): added commands with railway-cli to Publish CI.

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,3 +1,7 @@
+builds:
+- changed-files:
+  - any-glob-to-any-file: ['nixpacks.toml', 'Makefile']
+
 ci:
 - changed-files:
   - any-glob-to-any-file: ['.github/*.yml', '.github/*.yaml', '.github/workflows/**/*']
@@ -12,7 +16,7 @@ docs:
 
 deployment:
 - changed-files:
-  - any-glob-to-any-file: ['manifests/**/*']
+  - any-glob-to-any-file: ['manifests/**/*', 'railway.toml', 'nixpacks.toml', 'kind-cluster.yaml']
 
 tests:
 - changed-files:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}
+  RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
 
 jobs:
   build_and_ship:
@@ -30,3 +31,8 @@ jobs:
         with:
           push: true
           tags: ${{ env.IMAGE_NAME }}:latest
+
+      - name: Deploy app to Railway
+        run: |
+          curl -fsSL https://railway.com/install.sh | sh
+          RAILWAY_TOKEN=${{ env.RAILWAY_TOKEN }} railway up --service random-travelers --ci

--- a/railway.toml
+++ b/railway.toml
@@ -14,7 +14,8 @@ restartPolicyMaxRetries = 10
 
 numReplicas = 2
 
-[deploy.multiRegionConfig]
-# https://docs.railway.com/reference/deployment-regions
-asia-southeast1.numReplicas = 1
-us-west1.numReplicas = 1
+# Only available with Pro plan
+# [deploy.multiRegionConfig]
+# # https://docs.railway.com/reference/deployment-regions
+# asia-southeast1.numReplicas = 1
+# us-west1.numReplicas = 1


### PR DESCRIPTION
# Issue link
Relates: #115 

# Changes in this PR
- added jobs of installing `railway` commands to Publish CI
- added jobs to deploy application with RAILWAY_TOKEN

# Changes not included in this PR
- RAILWAY_TOKEN has been issued from Railway Dashboard and been configured as GitHub Secrets.
- e2e validation of Publish CI will not be included since it requires changes in `main` branches after merge this PR.