### PR TITLE
deploy: made dynamic on PORT for heroku.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn app.main:app --host 0.0.0.0 --port=8080 --reload
+web: python run.py

--- a/app/main.py
+++ b/app/main.py
@@ -71,4 +71,3 @@ app.include_router(
     prefix='/api/v1',
     tags=['API v1'],
 )
-

--- a/run.py
+++ b/run.py
@@ -1,0 +1,15 @@
+import os
+
+import uvicorn
+
+import app
+
+
+if __name__ == '__main__':
+    # https://github.com/encode/uvicorn/blob/4fdfec4adf1ba6da5e65c8422321e203b6050052/uvicorn/main.py#L464
+    uvicorn.run(
+        app="app.main:app",
+        host='0.0.0.0',
+        port=os.environ.get('PORT', 8000),
+        reload=True
+    )


### PR DESCRIPTION
# Issue link
N/A, SSIA
ref: https://help.heroku.com/W5ETWBQB/why-is-my-app-crashing-with-an-r10-error

For fixing the following error on application booting:

```log
2025-04-10T13:34:12.354835+00:00 heroku[web.1]: Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch
2025-04-10T13:34:12.369753+00:00 heroku[web.1]: Stopping process with SIGKILL
2025-04-10T13:34:12.426538+00:00 heroku[web.1]: Process exited with status 137
2025-04-10T13:34:12.450475+00:00 heroku[web.1]: State changed from starting to crashed
```

# Changes in this PR
SSIA, made dynamic of port number to listen, once after fetching PORT from runtime.

# Changes not included in this PR
N/A