### PR TITLE
deploy: fixed TypeError on uvicorn.run() with Heroku.

### DIFF
--- a/run.py
+++ b/run.py
@@ -6,10 +6,11 @@ import app
 
 
 if __name__ == '__main__':
-    # https://github.com/encode/uvicorn/blob/4fdfec4adf1ba6da5e65c8422321e203b6050052/uvicorn/main.py#L464
+    # https://github.com/encode/uvicorn/blob/master/uvicorn/main.py#L469
+    PORT: str = os.environ.get('PORT', '8000')
     uvicorn.run(
         app="app.main:app",
         host='0.0.0.0',
-        port=os.environ.get('PORT', 8000),
+        port=int(PORT),
         reload=True
     )


### PR DESCRIPTION
# Issue link
SSIA, for fixing the following error on Heroku.
It seems that Heroku will set `PORT` as **string** values, whereas the argument `port=` of `uvicorn.run()` is expecting int value.

```log
2025-04-10T14:48:53.432269+00:00 app[web.1]: Traceback (most recent call last):
2025-04-10T14:48:53.432823+00:00 app[web.1]: File "/app/run.py", line 10, in <module>
2025-04-10T14:48:53.432823+00:00 app[web.1]: uvicorn.run(
2025-04-10T14:48:53.432824+00:00 app[web.1]: ~~~~~~~~~~~^
2025-04-10T14:48:53.432824+00:00 app[web.1]: app="app.main:app",
2025-04-10T14:48:53.432824+00:00 app[web.1]: ^^^^^^^^^^^^^^^^^^^
2025-04-10T14:48:53.432825+00:00 app[web.1]: ...<2 lines>...
2025-04-10T14:48:53.432825+00:00 app[web.1]: reload=True
2025-04-10T14:48:53.432825+00:00 app[web.1]: ^^^^^^^^^^^
2025-04-10T14:48:53.432825+00:00 app[web.1]: )
2025-04-10T14:48:53.432825+00:00 app[web.1]: ^
2025-04-10T14:48:53.432827+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.13/site-packages/uvicorn/main.py", line 573, in run
2025-04-10T14:48:53.432827+00:00 app[web.1]: sock = config.bind_socket()
2025-04-10T14:48:53.432828+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.13/site-packages/uvicorn/config.py", line 515, in bind_socket
2025-04-10T14:48:53.432829+00:00 app[web.1]: sock.bind((self.host, self.port))
2025-04-10T14:48:53.432829+00:00 app[web.1]: ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-10T14:48:53.432846+00:00 app[web.1]: TypeError: 'str' object cannot be interpreted as an integer
2025-04-10T14:48:53.491597+00:00 heroku[web.1]: Process exited with status 1
2025-04-10T14:48:53.515037+00:00 heroku[web.1]: State changed from starting to crashed
```

# Changes in this PR
- added cast logics for arguments `port=` for `uvicorn.run()`

# Changes not included in this PR
N/A