### PR TITLE
fix(build): added fallback URL of MySQL credentials for Uvicorn app.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ show: --check-poetry --check-docker ## Show related components for app
 all: ## Start all componentes of random-traveler app
 	@make db
 	@make install
-	@poetry run uvicorn app.main:app --port=3000 --reload &
+	@JAWSDB_URL='mysql://root:root@0.0.0.0:3306/rt' poetry run uvicorn app.main:app --port=3000 --reload &
 
 
 clean: ## Remove components


### PR DESCRIPTION
# Issue link
Relates: #147 

Currently `make all` will fail because no database credentials would be passed on application startup, so this will cause the following TypeError with NoneType in `JAWSDB_URL`:

```shell
25-05-25 23:21:30 git/random-travelers [fix/147/makefile] % make all  
>>> Checking docker engine exists ...
Server: 28.1.1
Client: 28.1.1

>>> Starting MySQL container ...
bb75ae13058d4193da95a65605b0146172e8a1daac5e5ee220852b948d205b9e
Database is now healthy state

>>> Checking poetry installed ...
Poetry (version 2.1.1)

>>> Installing all packages required for application ...
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: random-travelers (0.6.1)
25-05-25 23:21:54 git/random-travelers [fix/147/makefile] % INFO:     Will watch for changes in these directories: ['/Users/hiro.wakabayashi/git/random-travelers']
INFO:     Uvicorn running on http://127.0.0.1:3000 (Press CTRL+C to quit)
INFO:     Started reloader process [27986] using StatReload
Process SpawnProcess-1:
Traceback (most recent call last):
# ...
  File "/Users/hiro.wakabayashi/git/random-travelers/app/api/v1/services.py", line 7, in <module>
    from app.config import app_settings
  File "/Users/hiro.wakabayashi/git/random-travelers/app/config.py", line 6, in <module>
    class AppSettings(BaseSettings):
    ...<8 lines>...
        GOOGLE_MAPS_API_KEY: str = ''
  File "/Users/hiro.wakabayashi/git/random-travelers/app/config.py", line 9, in AppSettings
    MYSQL_HOST: str = re.split('[:@/]', os.environ.get('JAWSDB_URL'))[5]
                      ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hiro.wakabayashi/.pyenv/versions/3.13.3/lib/python3.13/re/__init__.py", line 267, in split
    return _compile(pattern, flags).split(string, maxsplit)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```

# Changes in this PR
- added fallback URL of MySQL container in local environment

# Changes not included in this PR
N/A